### PR TITLE
Feature ignore external APIs

### DIFF
--- a/Config.json
+++ b/Config.json
@@ -2,5 +2,5 @@
 	"searchMoviesURL" : "https://perfeng-go-search.herokuapp.com/getMoviesByIds?ids=",
 	"authURL": "https://virtserver.swaggerhub.com/perfeng-loginteam/LoginService/1.0.0/isLoggedin?userId=",
 	"analyticsURL": "https://prod-analytics-boot.herokuapp.com/saveEdr",
-	"ignoreExternalAPIs": true
+	"ignoreExternalAPIs": false
 }

--- a/Config.json
+++ b/Config.json
@@ -1,5 +1,6 @@
 {
 	"searchMoviesURL" : "https://perfeng-go-search.herokuapp.com/getMoviesByIds?ids=",
 	"authURL": "https://virtserver.swaggerhub.com/perfeng-loginteam/LoginService/1.0.0/isLoggedin?userId=",
-	"analyticsURL": "https://prod-analytics-boot.herokuapp.com/saveEdr"
+	"analyticsURL": "https://prod-analytics-boot.herokuapp.com/saveEdr",
+	"ignoreExternalAPIs": true
 }

--- a/src/cs/usfca/edu/histfavcheckout/controller/HistFavCheckoutController.java
+++ b/src/cs/usfca/edu/histfavcheckout/controller/HistFavCheckoutController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import cs.usfca.edu.histfavcheckout.model.OperationalRequest;
 import cs.usfca.edu.histfavcheckout.model.OperationalResponse;
+import cs.usfca.edu.histfavcheckout.model.ConfigRequest;
 import cs.usfca.edu.histfavcheckout.model.Inventory;
 import cs.usfca.edu.histfavcheckout.model.PrimaryKey;
 import cs.usfca.edu.histfavcheckout.model.Product;
@@ -222,5 +223,11 @@ public class HistFavCheckoutController {
 	@ResponseBody()
 	public ResponseEntity<?> postMovie(@RequestBody Product movie) {
 		return handler.addMovie(movie);
+	}
+	
+	@PutMapping(value = "/config")
+	@ResponseBody()
+	public ResponseEntity<?> updateConfig(@RequestBody ConfigRequest request) {
+		return handler.updateConfig(request);
 	}
 }

--- a/src/cs/usfca/edu/histfavcheckout/controller/HistFavCheckoutHandler.java
+++ b/src/cs/usfca/edu/histfavcheckout/controller/HistFavCheckoutHandler.java
@@ -95,6 +95,7 @@ public class HistFavCheckoutHandler {
 	}
 	
 	public ResponseEntity<?> getCheckouts(int userId, int page, int nums) {
+		long st = System.currentTimeMillis();
 		//System.out.println("userId: " + userId + " page: " + page + " nums: " + nums);
 		List<User> userCheckedOutMovies = userRepository.findCheckedOutMovies(userId, true, 
 				PageRequest.of(page, nums, Sort.by("expectedReturnDate").descending()));
@@ -120,6 +121,7 @@ public class HistFavCheckoutHandler {
 			Movie mov = checkouts.newMovie(m.getTitle(), m.getID(), checkoutDate);
 			checkouts.addMovie(mov);
 		}
+		System.out.println("Elapsed time: " + (System.currentTimeMillis() - st));
 		return ResponseEntity.status(HttpStatus.OK).body(checkouts);		
 	}
 	

--- a/src/cs/usfca/edu/histfavcheckout/controller/HistFavCheckoutHandler.java
+++ b/src/cs/usfca/edu/histfavcheckout/controller/HistFavCheckoutHandler.java
@@ -95,7 +95,6 @@ public class HistFavCheckoutHandler {
 	}
 	
 	public ResponseEntity<?> getCheckouts(int userId, int page, int nums) {
-		long st = System.currentTimeMillis();
 		//System.out.println("userId: " + userId + " page: " + page + " nums: " + nums);
 		List<User> userCheckedOutMovies = userRepository.findCheckedOutMovies(userId, true, 
 				PageRequest.of(page, nums, Sort.by("expectedReturnDate").descending()));
@@ -121,7 +120,6 @@ public class HistFavCheckoutHandler {
 			Movie mov = checkouts.newMovie(m.getTitle(), m.getID(), checkoutDate);
 			checkouts.addMovie(mov);
 		}
-		System.out.println("Elapsed time: " + (System.currentTimeMillis() - st));
 		return ResponseEntity.status(HttpStatus.OK).body(checkouts);		
 	}
 	

--- a/src/cs/usfca/edu/histfavcheckout/controller/HistFavCheckoutHandler.java
+++ b/src/cs/usfca/edu/histfavcheckout/controller/HistFavCheckoutHandler.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Component;
 
 
 import cs.usfca.edu.histfavcheckout.externalapis.APIClient;
+import cs.usfca.edu.histfavcheckout.model.ConfigRequest;
 import cs.usfca.edu.histfavcheckout.model.GetUserCheckoutsResponse;
 import cs.usfca.edu.histfavcheckout.model.GetUserCheckoutsResponse.Movie;
 import cs.usfca.edu.histfavcheckout.model.OperationalResponse;
@@ -31,6 +32,7 @@ import cs.usfca.edu.histfavcheckout.model.Product;
 import cs.usfca.edu.histfavcheckout.model.ProductRepository;
 import cs.usfca.edu.histfavcheckout.model.SearchMoviesResponse;
 import cs.usfca.edu.histfavcheckout.model.SearchMoviesResponse.MovieData;
+import cs.usfca.edu.histfavcheckout.utils.Config;
 import cs.usfca.edu.histfavcheckout.model.TopRatedResponse;
 import cs.usfca.edu.histfavcheckout.model.RatingRequest;
 import cs.usfca.edu.histfavcheckout.model.RatingModel;
@@ -285,6 +287,11 @@ public class HistFavCheckoutHandler {
 	}
 
 
+	public ResponseEntity<?> updateConfig(ConfigRequest request) {
+		Config.config.setIgnoreExternalAPIs(request.getIgnoreExternalAPIs());
+		return ResponseEntity.status(HttpStatus.OK).body(new OperationalResponse(true, "config updated successfully"));
+	}
+	
 	/**
 	 * gives the expected return date
 	 * expected return date = current date + default number of days to borrow movie  

--- a/src/cs/usfca/edu/histfavcheckout/externalapis/APIClient.java
+++ b/src/cs/usfca/edu/histfavcheckout/externalapis/APIClient.java
@@ -22,10 +22,9 @@ public class APIClient {
 	
 	private static Request request = new Request();
 	private static Gson gson = new Gson();
-	private static boolean ignoreExternalAPIs = Config.config.getIgnoreExternalAPIs();
 	
 	public static SearchMoviesResponse getAllMovies(Set<Integer> movies) {
-		if(ignoreExternalAPIs) {
+		if(Config.config.getIgnoreExternalAPIs()) {
 			//TODO: Log this: System.out.println("Mocking response from search API");
 			SearchMoviesResponse resp = new SearchMoviesResponse();
 			resp.setSuccess(true);

--- a/src/cs/usfca/edu/histfavcheckout/externalapis/APIClient.java
+++ b/src/cs/usfca/edu/histfavcheckout/externalapis/APIClient.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -15,11 +16,13 @@ import cs.usfca.edu.histfavcheckout.utils.Config;
 import cs.usfca.edu.histfavcheckout.model.AuthResponse;
 import cs.usfca.edu.histfavcheckout.model.EDRRequest;
 import cs.usfca.edu.histfavcheckout.model.SearchMoviesResponse;
+import cs.usfca.edu.histfavcheckout.model.SearchMoviesResponse.MovieData;
 
 public class APIClient {
 	
 	private static Request request = new Request();
 	private static Gson gson = new Gson();
+	private static boolean ignoreExternalAPIs = Config.config.getIgnoreExternalAPIs();
 	
 	public static SearchMoviesResponse getAllMovies(Set<Integer> movies) {
 		URL url = request.url(Config.config.getSearchMoviesURL() + movieIds(movies));
@@ -27,12 +30,16 @@ public class APIClient {
 		
 		String response = request.getResponse(con);
 		if (response != null) {
-			System.out.println("Received : " + response.toString());
+			//TODO: Log this: System.out.println("Received : " + response.toString());
 			SearchMoviesResponse resp = gson.fromJson(response.toString(), SearchMoviesResponse.class);
 			return resp;
 		}
-		else {
-			System.out.println("No response from " + url.toString());
+		else if(ignoreExternalAPIs) {
+			//TODO: Log this: System.out.println("No response from " + url.toString());
+			SearchMoviesResponse resp = new SearchMoviesResponse();
+			resp.setSuccess(true);
+			resp.setResults(Collections.nCopies(movies.size(), mockMovie()));
+			return resp;
 		}
 		con.disconnect();
 		return null;
@@ -70,5 +77,18 @@ public class APIClient {
 		int responseCode = con.getResponseCode();
 		con.disconnect();
 		return responseCode;
+	}
+	
+	private static MovieData mockMovie() {
+		final MovieData m = new MovieData();
+		m.setID(1);
+		m.setGenre("Action");
+		m.setPrice("10000");
+		m.setRating("5.0");
+		m.setStudio("Hist Fave Team Studios");
+		m.setTitle("Mocking You");
+		m.setUpc("AX637228");
+		m.setYear("5500");
+		return m;
 	}
 }

--- a/src/cs/usfca/edu/histfavcheckout/model/ConfigRequest.java
+++ b/src/cs/usfca/edu/histfavcheckout/model/ConfigRequest.java
@@ -1,0 +1,11 @@
+package cs.usfca.edu.histfavcheckout.model;
+
+import java.io.Serializable;
+
+public class ConfigRequest implements Serializable {
+	private boolean ignoreExternalAPIs;
+	
+	public boolean getIgnoreExternalAPIs() {
+		return ignoreExternalAPIs;
+	}
+}

--- a/src/cs/usfca/edu/histfavcheckout/model/SearchMoviesResponse.java
+++ b/src/cs/usfca/edu/histfavcheckout/model/SearchMoviesResponse.java
@@ -7,11 +7,19 @@ public class SearchMoviesResponse {
 	private List<MovieData> results;
 	private boolean success;
 	
+	public void setResults(List<MovieData> results) {
+		this.results = results;
+	}
+	
 	public List<MovieData> getResults() {
 		return results;
 	}
 	public boolean isSuccess() {
 		return success;
+	}
+	
+	public void setSuccess(boolean success) {
+		this.success = success;
 	}
 	
 	public MovieData newMovieData() {
@@ -51,6 +59,30 @@ public class SearchMoviesResponse {
 		}
 		public int getID() {
 			return ID;
+		}
+		public void setTitle(String title) {
+			Title = title;
+		}
+		public void setStudio(String studio) {
+			Studio = studio;
+		}
+		public void setPrice(String price) {
+			Price = price;
+		}
+		public void setRating(String rating) {
+			Rating = rating;
+		}
+		public void setYear(String year) {
+			Year = year;
+		}
+		public void setGenre(String genre) {
+			Genre = genre;
+		}
+		public void setUpc(String upc) {
+			Upc = upc;
+		}
+		public void setID(int iD) {
+			ID = iD;
 		}
 	}
 }

--- a/src/cs/usfca/edu/histfavcheckout/utils/Config.java
+++ b/src/cs/usfca/edu/histfavcheckout/utils/Config.java
@@ -37,6 +37,10 @@ public class Config {
 		return this.ignoreExternalAPIs;
 	}
 	
+	public void setIgnoreExternalAPIs(boolean ignore) {
+		config.ignoreExternalAPIs = ignore;
+	}
+	
 	//read config file and create class object
 	public static Config readConfig(String path) throws IOException {
 		Gson gson = new GsonBuilder().create();

--- a/src/cs/usfca/edu/histfavcheckout/utils/Config.java
+++ b/src/cs/usfca/edu/histfavcheckout/utils/Config.java
@@ -18,6 +18,7 @@ public class Config {
 	private String searchMoviesURL;
 	private String authURL;
 	private String analyticsURL;
+	private boolean ignoreExternalAPIs;
 	
 	//getters
 	public String getSearchMoviesURL() {
@@ -30,6 +31,10 @@ public class Config {
 	
 	public String getAnalyticsURL() {
 		return this.analyticsURL;
+	}
+	
+	public boolean getIgnoreExternalAPIs() {
+		return this.ignoreExternalAPIs;
 	}
 	
 	//read config file and create class object


### PR DESCRIPTION
Implemented feature to skip calling `search /getMoviesByIds` API and use mock data instead. When this feature is turned on, the processing time is reduced by ~100ms. All our APIs that call search APIs internally should perform faster when this feature is toggled on. This feature can be set via the config file OR by calling the `/config API` shown below.


For example, calling the `PUT /config` API to toggle the ignoreExternalAPIs on:
API EndPoint: https://hsit-fav-che-feature-ig-fukxlt.herokuapp.com/config
RequestBody:
`{
	"ignoreExternalAPIs":true
}`


**You can see the results of the above config by testing relevant APIs:**

One such API to test this is the `GET /checkedOutMovies` API

Test Env : https://hsit-fav-che-feature-ig-fukxlt.herokuapp.com/

Test userId : 2
Example Request : https://hsit-fav-che-feature-ig-fukxlt.herokuapp.com/checkedOutMovies?userId=2&page=0&nums=10
