### PR TITLE
Feature ignore external apis - Login & EDR

### DIFF
--- a/src/cs/usfca/edu/histfavcheckout/externalapis/APIClient.java
+++ b/src/cs/usfca/edu/histfavcheckout/externalapis/APIClient.java
@@ -25,7 +25,6 @@ public class APIClient {
 	
 	public static SearchMoviesResponse getAllMovies(Set<Integer> movies) {
 		if(Config.config.getIgnoreExternalAPIs()) {
-			//TODO: Log this: System.out.println("Mocking response from search API");
 			SearchMoviesResponse resp = new SearchMoviesResponse();
 			resp.setSuccess(true);
 			resp.setResults(Collections.nCopies(movies.size(), mockMovie(movies.iterator().next())));
@@ -56,6 +55,9 @@ public class APIClient {
 	}
 	
 	public static boolean isAuthenticated(int userId) throws IOException {
+		if(Config.config.getIgnoreExternalAPIs()) {
+			return true;
+		}
 		URL url = new URL(Config.config.getAuthURL() + userId);
 		HttpURLConnection con = request.connect(url, "GET");
 		String response = request.getResponse(con);
@@ -69,6 +71,9 @@ public class APIClient {
 	}
 	
 	public static int sendEDR(EDRRequest edrRequest) throws IOException {
+		if(Config.config.getIgnoreExternalAPIs()) {
+			return HttpURLConnection.HTTP_OK;
+		}
 		URL url = new URL(Config.config.getAnalyticsURL());
 		HttpURLConnection con = request.connect(url, "POST", MediaType.APPLICATION_JSON_VALUE, null);
 		request.writeToBody(con, gson.toJson(edrRequest));


### PR DESCRIPTION
Implemented feature to skip calling `get /isLoggedIn` and `post /saveEdr` APIs and use mock data instead. This feature can be set via the config file OR by calling the `/config API` shown below. Basically adding to the changes in Pull Request https://github.com/usfcs-perf-eng-s20/heroku-project-favs/pull/11

**You can see the results of the above config by testing relevant APIs:**

One such API to test this is the `GET /checkedOutMovies` API

Test Env : https://hsit-fav-che-feature-ig-l6abfc.herokuapp.com/

Test userId : 2
Example Request : https://hsit-fav-che-feature-ig-l6abfc.herokuapp.com/checkedOutMovies?userId=2&page=0&nums=10
