### PR TITLE
Fixed getTopUsers with pagination and call to auth service

### DIFF
--- a/Config.json
+++ b/Config.json
@@ -1,6 +1,7 @@
 {
 	"searchMoviesURL" : "https://perfeng-go-search.herokuapp.com/getMoviesByIds?ids=",
 	"authURL": "https://virtserver.swaggerhub.com/perfeng-loginteam/LoginService/1.0.0/isLoggedin?userId=",
+	"userInfoURL": "https://gentle-spire-73113.herokuapp.com//getUserInfo?userId=",
 	"analyticsURL": "https://prod-analytics-boot.herokuapp.com/saveEdr",
 	"ignoreExternalAPIs": false
 }

--- a/src/cs/usfca/edu/histfavcheckout/controller/HistFavCheckoutController.java
+++ b/src/cs/usfca/edu/histfavcheckout/controller/HistFavCheckoutController.java
@@ -122,9 +122,9 @@ public class HistFavCheckoutController {
 	@GetMapping(value = "/getTopUsers")
 	@ResponseBody()
 	public ResponseEntity<?> getTopUsers(@ApiParam(value = "Checkouts, Faves and Ratings per user can be selected", required = true) @RequestParam String selected, 
-			@ApiParam(value = "index to start fetching movies", required = true) @RequestParam int start, 
+			@ApiParam(value = "index to start fetching movies", required = true) @RequestParam int page, 
 			@ApiParam(value = "number of movies per page to return", required = true) @RequestParam int nums) {
-		return handler.getTopUsers(selected, start, nums);
+		return handler.getTopUsers(selected, page, nums);
 	}
 	
 	@ApiOperation(value = "Returns all the favorite movies and the total number of movies checked out for the user", response = List.class)

--- a/src/cs/usfca/edu/histfavcheckout/filters/AnalyticsFilter.java
+++ b/src/cs/usfca/edu/histfavcheckout/filters/AnalyticsFilter.java
@@ -39,8 +39,8 @@ public class AnalyticsFilter implements Filter {
 						System.currentTimeMillis() - timestamp, String.valueOf(res.getStatus()), SERVICE_NAME, 
 						success, String.valueOf(timestamp), "");
 				try {
-					int responseCode = APIClient.sendEDR(edrRequest);
-					if(responseCode != HttpURLConnection.HTTP_OK) {
+					boolean success = APIClient.sendEDR(edrRequest);
+					if(success) {
 						//System.out.println("EDR Event responded with non 200 responseCode: " + responseCode + " response!");
 						// LOG here EDR responded non 200 status and log what status was returned. 
 					}

--- a/src/cs/usfca/edu/histfavcheckout/model/TopUser.java
+++ b/src/cs/usfca/edu/histfavcheckout/model/TopUser.java
@@ -1,0 +1,52 @@
+package cs.usfca.edu.histfavcheckout.model;
+
+public class TopUser {
+	
+	private int userId;
+	private long favsCount;
+	private long checkoutsCount;
+	private long ratingsCount;
+	
+	public TopUser() {}
+	
+	public TopUser(int userId, long favsCount, long checkoutsCount, long ratingsCount) {
+		this.userId = userId;
+		this.favsCount = favsCount;
+		this.checkoutsCount = checkoutsCount;
+		this.ratingsCount = ratingsCount;
+	}
+
+	public int getUserId() {
+		return userId;
+	}
+
+	public void setUserId(int userId) {
+		this.userId = userId;
+	}
+
+	public long getFavsCount() {
+		return favsCount;
+	}
+
+	public void setFavsCount(long favsCount) {
+		this.favsCount = favsCount;
+	}
+
+	public long getCheckoutsCount() {
+		return checkoutsCount;
+	}
+
+	public void setCheckoutsCount(long checkoutsCount) {
+		this.checkoutsCount = checkoutsCount;
+	}
+
+	public long getRatingsCount() {
+		return ratingsCount;
+	}
+
+	public void setRatingsCount(long ratingsCount) {
+		this.ratingsCount = ratingsCount;
+	}
+
+	
+}

--- a/src/cs/usfca/edu/histfavcheckout/model/TopUserResponse.java
+++ b/src/cs/usfca/edu/histfavcheckout/model/TopUserResponse.java
@@ -1,0 +1,65 @@
+package cs.usfca.edu.histfavcheckout.model;
+
+import java.io.Serializable;
+
+public class TopUserResponse implements Serializable {
+	private String userName;
+	private String email;
+	private long favsCount;
+	private long checkoutsCount;
+	private long ratingsCount;
+	
+	public TopUserResponse() {}
+	
+	public TopUserResponse(String userName, String email, long favsCount, long checkoutsCount, long ratingsCount) {
+		this.userName = userName;
+		this.email = email;
+		this.favsCount = favsCount;
+		this.checkoutsCount = checkoutsCount;
+		this.ratingsCount = ratingsCount;
+	}
+
+	public String getUserName() {
+		return userName;
+	}
+
+	public void setUserName(String userName) {
+		this.userName = userName;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public long getFavsCount() {
+		return favsCount;
+	}
+
+	public void setFavsCount(long favsCount) {
+		this.favsCount = favsCount;
+	}
+
+	public long getCheckoutsCount() {
+		return checkoutsCount;
+	}
+
+	public void setCheckoutsCount(long checkoutsCount) {
+		this.checkoutsCount = checkoutsCount;
+	}
+
+	public long getRatingsCount() {
+		return ratingsCount;
+	}
+
+	public void setRatingsCount(long ratingsCount) {
+		this.ratingsCount = ratingsCount;
+	}
+
+	
+	
+	
+}

--- a/src/cs/usfca/edu/histfavcheckout/model/UserInfoResponse.java
+++ b/src/cs/usfca/edu/histfavcheckout/model/UserInfoResponse.java
@@ -1,0 +1,59 @@
+package cs.usfca.edu.histfavcheckout.model;
+
+import java.util.List;
+
+public class UserInfoResponse {
+	private List<UserInfo> users;
+	
+	public void setUsers(List<UserInfo> users) {
+		this.users = users;
+	}
+	
+	public List<UserInfo> getUsers() {
+		return users;
+	}
+	
+	public UserInfo newUserInfo() {
+		return new UserInfo();
+	}
+	
+	public static class UserInfo {
+		private int userId;
+		private String userName;
+		private String email;
+		
+		public UserInfo() {}
+		
+		public UserInfo(int userId, String userName, String email) {
+			this.userId = userId;
+			this.userName = userName;
+			this.email = email;
+		}
+
+		public int getUserId() {
+			return userId;
+		}
+
+		public void setUserId(int userId) {
+			this.userId = userId;
+		}
+
+		public String getUserName() {
+			return userName;
+		}
+
+		public void setUserName(String userName) {
+			this.userName = userName;
+		}
+
+		public String getEmail() {
+			return email;
+		}
+
+		public void setEmail(String email) {
+			this.email = email;
+		}
+		
+		
+	}
+}

--- a/src/cs/usfca/edu/histfavcheckout/model/UserRepository.java
+++ b/src/cs/usfca/edu/histfavcheckout/model/UserRepository.java
@@ -39,12 +39,25 @@ public interface UserRepository extends JpaRepository<User, PrimaryKey> {
 	@Query("UPDATE User u SET u.actualReturnDate = :actualReturnDate WHERE u.id = :id")
 	public int updateCheckoutReturn(@Param("id") PrimaryKey id, @Param("actualReturnDate") Date actualReturnDate);
 	
-	@Query("SELECT u FROM User u where u.favourites = :favourites")
-	public List<User> findUserFavourites(@Param("favourites") boolean favorites);
+	@Query("SELECT new cs.usfca.edu.histfavcheckout.model.TopUser(u.id.userId, "
+			+ "count(case when favourites=TRUE then 1 end) as favs, "
+			+ "count(case when checkouts=TRUE then 1 end) as checks, "
+			+ "count(case when rating > 0 then 1 end) as rates) "
+			+ "FROM User u GROUP BY u.id.userId ORDER BY favs DESC")
+	public List<TopUser> getTopUserFavourites(Pageable pageable);
 	
-	@Query("SELECT u FROM User u where u.checkouts = :checkouts")
-	public List<User> findUserCheckouts(@Param("checkouts") boolean checkouts);
+	@Query("SELECT new cs.usfca.edu.histfavcheckout.model.TopUser(u.id.userId, "
+			+ "count(case when favourites=TRUE then 1 end) as favs, "
+			+ "count(case when checkouts=TRUE then 1 end) as checks, "
+			+ "count(case when rating > 0 then 1 end) as rates) "
+			+ "FROM User u GROUP BY u.id.userId ORDER BY checks DESC")
+	public List<TopUser> getTopUserCheckouts(Pageable pageable);
 	
-	@Query("SELECT u FROM User u where u.rating BETWEEN 0 AND 5")
-	public List<User> findTopRaters();
+	@Query("SELECT new cs.usfca.edu.histfavcheckout.model.TopUser(u.id.userId, "
+			+ "count(case when favourites=TRUE then 1 end) as favs, "
+			+ "count(case when checkouts=TRUE then 1 end) as checks, "
+			+ "count(case when rating > 0 then 1 end) as rates) "
+			+ "FROM User u GROUP BY u.id.userId ORDER BY rates DESC")
+	public List<TopUser> getTopRaters(Pageable pageable);
+
 }

--- a/src/cs/usfca/edu/histfavcheckout/utils/Config.java
+++ b/src/cs/usfca/edu/histfavcheckout/utils/Config.java
@@ -7,8 +7,6 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 
-import org.springframework.stereotype.Component;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
@@ -18,6 +16,7 @@ public class Config {
 	private String searchMoviesURL;
 	private String authURL;
 	private String analyticsURL;
+	private String userInfoURL;
 	private boolean ignoreExternalAPIs;
 	
 	//getters
@@ -31,6 +30,10 @@ public class Config {
 	
 	public String getAnalyticsURL() {
 		return this.analyticsURL;
+	}
+	
+	public String getUserInfoURL() {
+		return this.userInfoURL;
 	}
 	
 	public boolean getIgnoreExternalAPIs() {


### PR DESCRIPTION
Implemented getTopUser with pagination. Also, calling UserService for userInfo data. However, their APIs for getUserInfo is still under development. I tested by mocking the data locally using the only two UserIds (Check the link below) that are working right now. 

UserInfoLink: https://gentle-spire-73113.herokuapp.com//getUserInfo?userId=535,536

Since, their APIs are not fully functional please set, the below `ignoreExternalAPIs` config as true.

Config Endpoint: https://hist-fav-checkout.herokuapp.com/config
```
{ 
    "ignoreExternalAPIs":true
}
```

Then call, GetTopUsers by Checkout: 

Endpoint: https://hist-fav-checkout.herokuapp.com/getTopUsers?selected=checkouts&page=0&nums=10

