### PR TITLE
useAPI toggle can now be turned  on/off for specific APIs

### DIFF
--- a/Config.json
+++ b/Config.json
@@ -3,5 +3,8 @@
 	"authURL": "https://virtserver.swaggerhub.com/perfeng-loginteam/LoginService/1.0.0/isLoggedin?userId=",
 	"userInfoURL": "https://gentle-spire-73113.herokuapp.com//getUserInfo?userId=",
 	"analyticsURL": "https://prod-analytics-boot.herokuapp.com/saveEdr",
-	"ignoreExternalAPIs": false
+	"useFavesAPIs":true,
+	"useSearchAPIs": true,
+	"useLoginAPIs": true,
+	"useAnalyticsAPIs": true
 }

--- a/src/cs/usfca/edu/histfavcheckout/controller/HistFavCheckoutHandler.java
+++ b/src/cs/usfca/edu/histfavcheckout/controller/HistFavCheckoutHandler.java
@@ -367,8 +367,10 @@ public class HistFavCheckoutHandler {
 	}
 
 	public ResponseEntity<?> updateConfig(ConfigRequest request) {
-		Config.config.setIgnoreExternalAPIs(request.getIgnoreExternalAPIs());
-		return ResponseEntity.status(HttpStatus.OK).body(new OperationalResponse(true, "config updated successfully"));
+		Config.config.setUseLoginAPIs(request.getLogin());
+		Config.config.setUseSearchAPIs(request.getSearch());
+		Config.config.setUseAnalyticsAPIs(request.getAnalytics());
+		return ResponseEntity.status(HttpStatus.OK).body(new OperationalResponse(true, "Config updated successfully"));
 	}
 	
 	/**

--- a/src/cs/usfca/edu/histfavcheckout/externalapis/APIClient.java
+++ b/src/cs/usfca/edu/histfavcheckout/externalapis/APIClient.java
@@ -26,7 +26,7 @@ public class APIClient {
 	private static Gson gson = new Gson();
 	
 	public static SearchMoviesResponse getAllMovies(Set<Integer> movies) {
-		if(Config.config.getIgnoreExternalAPIs()) {
+		if(!Config.config.getUseSearchAPIs()) {
 			SearchMoviesResponse resp = new SearchMoviesResponse();
 			resp.setSuccess(true);
 			resp.setResults(Collections.nCopies(movies.size(), mockMovie(movies.iterator().next())));
@@ -45,7 +45,7 @@ public class APIClient {
 	}
 	
 	public static List<UserInfoResponse.UserInfo> getTopUsers(Set<Integer> userIds) {
-		if(Config.config.getIgnoreExternalAPIs()) {
+		if(!Config.config.getUseLoginAPIs()) {
 			return mockUsers(userIds);
 		}
 		URL url = request.url(Config.config.getUserInfoURL() + generateRequestList(userIds));
@@ -73,7 +73,7 @@ public class APIClient {
 	}
 	
 	public static boolean isAuthenticated(int userId) throws IOException {
-		if(Config.config.getIgnoreExternalAPIs()) {
+		if(!Config.config.getUseLoginAPIs()) {
 			return true;
 		}
 		URL url = new URL(Config.config.getAuthURL() + userId);
@@ -89,7 +89,7 @@ public class APIClient {
 	}
 	
 	public static boolean sendEDR(EDRRequest edrRequest) throws IOException {
-		if(Config.config.getIgnoreExternalAPIs()) {
+		if(!Config.config.getUseAnalyticsAPIs()) {
 			return true;
 		}
 		URL url = new URL(Config.config.getAnalyticsURL());

--- a/src/cs/usfca/edu/histfavcheckout/model/ConfigRequest.java
+++ b/src/cs/usfca/edu/histfavcheckout/model/ConfigRequest.java
@@ -3,9 +3,24 @@ package cs.usfca.edu.histfavcheckout.model;
 import java.io.Serializable;
 
 public class ConfigRequest implements Serializable {
-	private boolean ignoreExternalAPIs;
+	private boolean faves;
+	private boolean search;
+	private boolean login;
+	private boolean analytics;
 	
-	public boolean getIgnoreExternalAPIs() {
-		return ignoreExternalAPIs;
+	public boolean getFaves() {
+		return faves;
+	}
+	
+	public boolean getSearch() {
+		return search;
+	}
+	
+	public boolean getLogin() {
+		return login;
+	}
+	
+	public boolean getAnalytics() {
+		return analytics;
 	}
 }

--- a/src/cs/usfca/edu/histfavcheckout/utils/Config.java
+++ b/src/cs/usfca/edu/histfavcheckout/utils/Config.java
@@ -17,8 +17,10 @@ public class Config {
 	private String authURL;
 	private String analyticsURL;
 	private String userInfoURL;
-	private boolean ignoreExternalAPIs;
-	
+	private boolean useFavesAPIs;
+	private boolean useSearchAPIs;
+	private boolean useLoginAPIs;
+	private boolean useAnalyticsAPIs;
 	//getters
 	public String getSearchMoviesURL() {
 		return this.searchMoviesURL;
@@ -36,12 +38,34 @@ public class Config {
 		return this.userInfoURL;
 	}
 	
-	public boolean getIgnoreExternalAPIs() {
-		return this.ignoreExternalAPIs;
+	public boolean getUseFavesAPIs() {
+		return this.useFavesAPIs;
 	}
 	
-	public void setIgnoreExternalAPIs(boolean ignore) {
-		config.ignoreExternalAPIs = ignore;
+	public void setUseFavesAPIs(boolean value) {
+		config.useFavesAPIs = value;
+	}
+	
+	public boolean getUseSearchAPIs() {
+		return this.useSearchAPIs;
+	}
+	
+	public void setUseSearchAPIs(boolean value) {
+		config.useSearchAPIs = value;
+	}
+	public boolean getUseLoginAPIs() {
+		return this.useLoginAPIs;
+	}
+	
+	public void setUseLoginAPIs(boolean value) {
+		config.useLoginAPIs = value;
+	}
+	public boolean getUseAnalyticsAPIs() {
+		return this.useAnalyticsAPIs;
+	}
+	
+	public void setUseAnalyticsAPIs(boolean value) {
+		config.useAnalyticsAPIs = value;
 	}
 	
 	//read config file and create class object


### PR DESCRIPTION
Implemented feature to skip calling each external API specifically. This feature can be set via the config file OR by calling the `/config API` shown below.

To achieve this, call the `PUT /config` API with the following
API EndPoint: https://hist-fav-checkout.herokuapp.com/config
Request Body
`{
       "faves": false,
       "search": false,
       "login": false,
       "analytics": true
}`

**You can see the results of the above config by testing relevant APIs:**

One such API to test this is the `GET /checkedOutMovies` API

Test Env : https://hist-fav-checkout.herokuapp.com/

Test userId : 2
Example Request : https://hist-fav-checkout.herokuapp.com/checkedOutMovies?userId=2&page=0&nums=10

